### PR TITLE
ci: configure Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+updates:
+  # Enable version updates for npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "Fundacao-1Bi/aprendizap-core"
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    # Group minor and patch updates
+    groups:
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "patch"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## 🤖 Configuração do Dependabot

Este PR adiciona a configuração do Dependabot para automatizar atualizações de dependências.

### O que está sendo configurado:

**Para dependências NPM:**
- ✅ Verificação semanal (segundas, 9h)
- ✅ Até 5 PRs abertos simultaneamente
- ✅ Agrupa atualizações minor/patch para reduzir ruído

**Para GitHub Actions:**
- ✅ Verificação semanal
- ✅ Até 3 PRs abertos

### Benefícios:

- 🔒 Mantém dependências atualizadas com patches de segurança
- 📦 Reduz trabalho manual de atualização
- 🎯 PRs organizados e agrupados por tipo

---

*Criado automaticamente pelo script de rollout do Dependabot.*