### PR TITLE
ci: add CodeBuild Lambda runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on:
+      - codebuild-azp-gha-linux-lambda-1gb-${{ github.run_id }}-${{ github.run_attempt }}
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary

- Add a GitHub Actions CI workflow for pull requests and pushes to `main`.
- Run the lightweight Vite lint/build job on the new CodeBuild Lambda 1GB runner.

## Sizing decision

This repo did not have `.github/workflows` on `main`. The project is a small Vite app with `npm ci`, `npm run lint`, and `npm run build`, no Docker, no deploy, no VPC access, and local build completed quickly after dependencies were installed. That matches the intended use case for `linux-lambda-1gb`.

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/*.yml`
- `npm ci`
- `npm run lint` passed with existing warnings only
- `npm run build`

## Rollback

Remove `.github/workflows/ci.yml` or change `runs-on` back to `ubuntu-latest`.