### PR TITLE
ci: remove unused GitHub Actions updater

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,19 +29,3 @@ updates:
         dependency-type: "production"
         update-types:
           - "patch"
-
-  # Enable version updates for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    target-branch: "develop"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "America/Sao_Paulo"
-    open-pull-requests-limit: 3
-    labels:
-      - "dependencies"
-      - "github-actions"
-    commit-message:
-      prefix: "ci"


### PR DESCRIPTION
## Summary
- remove the Dependabot github-actions updater from develop
- this repository has no .github/workflows files, so the updater fails without actionable updates

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/dependabot.yml'); puts 'dependabot yaml ok'"
- git diff --check